### PR TITLE
Move StackdriverExporter implementation from OpenCensus core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": ">=5.6",
-        "opencensus/opencensus": "^0.2",
+        "opencensus/opencensus": "^0.4",
         "google/cloud-trace": "^0.4"
     },
     "require-dev": {
@@ -21,7 +21,7 @@
     "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
-            "OpenCensus\\Trace\\": "src/Trace/"
+            "OpenCensus\\Trace\\Exporter\\": "src/"
         }
     }
 }

--- a/src/Stackdriver/SpanConverter.php
+++ b/src/Stackdriver/SpanConverter.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Exporter\Stackdriver;
+
+use Google\Cloud\Trace\Span;
+use OpenCensus\Trace\Span as OCSpan;
+use OpenCensus\Trace\SpanData;
+
+/**
+ * This class handles converting from the OpenCensus data model into its
+ * Stackdriver Trace representation.
+ */
+class SpanConverter
+{
+    const ATTRIBUTE_MAP = [
+        OCSpan::ATTRIBUTE_HOST => '/http/host',
+        OCSpan::ATTRIBUTE_PORT => '/http/port',
+        OCSpan::ATTRIBUTE_METHOD => '/http/method',
+        OCSpan::ATTRIBUTE_PATH => '/http/url',
+        OCSpan::ATTRIBUTE_USER_AGENT => '/http/user_agent',
+        OCSpan::ATTRIBUTE_STATUS_CODE => '/http/status_code'
+    ];
+
+    /**
+     * Convert an OpenCensus SpanData to its Stackdriver Trace representation.
+     *
+     * @access private
+     *
+     * @param SpanData $span The span to convert.
+     * @return Span
+     */
+    public static function convertSpan(SpanData $span)
+    {
+        return new Span($span->traceId(), [
+            'name' => $span->name(),
+            'startTime' => $span->startTime(),
+            'endTime' => $span->endTime(),
+            'spanId' => $span->spanId(),
+            'parentSpanId' => $span->parentSpanId(),
+            'attributes' => self::convertAttributes($span->attributes()),
+            'stackTrace' => $span->stackTrace()
+        ]);
+    }
+
+    private static function convertAttributes(array $attributes)
+    {
+        $newAttributes = [];
+        foreach ($attributes as $key => $value) {
+            if (array_key_exists($key, self::ATTRIBUTE_MAP)) {
+                $newAttributes[self::ATTRIBUTE_MAP[$key]] = $value;
+            } else {
+                $newAttributes[$key] = $value;
+            }
+        }
+        return $newAttributes;
+    }
+}

--- a/src/Stackdriver/SpanConverter.php
+++ b/src/Stackdriver/SpanConverter.php
@@ -17,8 +17,16 @@
 
 namespace OpenCensus\Trace\Exporter\Stackdriver;
 
+use Google\Cloud\Trace\Annotation;
+use Google\Cloud\Trace\Link;
+use Google\Cloud\Trace\MessageEvent;
 use Google\Cloud\Trace\Span;
+use Google\Cloud\Trace\Status;
+use OpenCensus\Trace\Annotation as OCAnnotation;
+use OpenCensus\Trace\Link as OCLink;
+use OpenCensus\Trace\MessageEvent as OCMessageEvent;
 use OpenCensus\Trace\Span as OCSpan;
+use OpenCensus\Trace\Status as OCStatus;
 use OpenCensus\Trace\SpanData;
 
 /**
@@ -35,6 +43,16 @@ class SpanConverter
         OCSpan::ATTRIBUTE_USER_AGENT => '/http/user_agent',
         OCSpan::ATTRIBUTE_STATUS_CODE => '/http/status_code'
     ];
+    const LINK_TYPE_MAP = [
+        OCLink::TYPE_UNSPECIFIED => Link::TYPE_UNSPECIFIED,
+        OCLink::TYPE_CHILD_LINKED_SPAN => Link::TYPE_CHILD_LINKED_SPAN,
+        OCLink::TYPE_PARENT_LINKED_SPAN => Link::TYPE_PARENT_LINKED_SPAN
+    ];
+    const MESSAGE_TYPE_MAP = [
+        OCMessageEvent::TYPE_UNSPECIFIED => MessageEvent::TYPE_UNSPECIFIED,
+        OCMessageEvent::TYPE_SENT => MessageEvent::TYPE_SENT,
+        OCMessageEvent::TYPE_RECEIVED => MessageEvent::TYPE_RECEIVED
+    ];
 
     /**
      * Convert an OpenCensus SpanData to its Stackdriver Trace representation.
@@ -46,15 +64,21 @@ class SpanConverter
      */
     public static function convertSpan(SpanData $span)
     {
-        return new Span($span->traceId(), [
+        $spanOptions = [
             'name' => $span->name(),
             'startTime' => $span->startTime(),
             'endTime' => $span->endTime(),
             'spanId' => $span->spanId(),
-            'parentSpanId' => $span->parentSpanId(),
             'attributes' => self::convertAttributes($span->attributes()),
-            'stackTrace' => $span->stackTrace()
-        ]);
+            'stackTrace' => $span->stackTrace(),
+            'links' => self::convertLinks($span->links()),
+            'timeEvents' => self::convertTimeEvents($span->timeEvents()),
+            'status' => self::convertStatus($span->status())
+        ];
+        if ($span->parentSpanId()) {
+            $spanOptions['parentSpanId'] = $span->parentSpanId();
+        }
+        return new Span($span->traceId(), $spanOptions);
     }
 
     private static function convertAttributes(array $attributes)
@@ -68,5 +92,53 @@ class SpanConverter
             }
         }
         return $newAttributes;
+    }
+
+    private static function convertLinks(array $links)
+    {
+        return array_map(function (OCLink $link) {
+            return new Link($link->traceId(), $link->spanId(), [
+                'type' => self::LINK_TYPE_MAP[$link->type()],
+                'attributes' => $link->attributes()
+            ]);
+        }, $links);
+    }
+
+    private static function convertTimeEvents(array $events)
+    {
+        $newEvents = [];
+        foreach ($events as $event) {
+            if ($event instanceof OCAnnotation) {
+                $newEvents[] = self::convertAnnotation($event);
+            } elseif ($event instanceof OCMessageEvent) {
+                $newEvents[] = self::convertMessageEvent($event);
+            }
+        }
+        return $newEvents;
+    }
+
+    private static function convertAnnotation(OCAnnotation $annotation)
+    {
+        return new Annotation($annotation->description(), [
+            'attributes' => $annotation->attributes()
+        ]);
+    }
+
+    private static function convertMessageEvent(OCMessageEvent $messageEvent)
+    {
+        return new MessageEvent($messageEvent->id(), [
+            'type' => self::MESSAGE_TYPE_MAP[$messageEvent->type()],
+            'uncompressedSizeBytes' => $messageEvent->uncompressedSize(),
+            'compressedSizeBytes' => $messageEvent->compressedSize()
+        ]);
+    }
+
+    private static function convertStatus(OCStatus $status = null)
+    {
+        if ($status) {
+            return new Status($status->code(), $status->message());
+        } else {
+            return null;
+        }
     }
 }

--- a/src/StackdriverExporter.php
+++ b/src/StackdriverExporter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017 OpenCensus Authors
+ * Copyright 2018 OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/Stackdriver/SpanConverterTest.php
+++ b/tests/unit/Stackdriver/SpanConverterTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017 OpenCensus Authors
+ * Copyright 2018 OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/Stackdriver/SpanConverterTest.php
+++ b/tests/unit/Stackdriver/SpanConverterTest.php
@@ -33,6 +33,8 @@ use PHPUnit\Framework\TestCase;
  */
 class SpanConverterTest extends TestCase
 {
+    const TIMESTAMP_FORMAT_REGEXP = '/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/';
+
     /**
      * @var SpanData[]
      */
@@ -65,8 +67,8 @@ class SpanConverterTest extends TestCase
         $this->assertInternalType('string', $span->name());
         $this->assertInternalType('string', $span->spanId());
         $this->assertNull($span->parentSpanId());
-        $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $span->jsonSerialize()['startTime']);
-        $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $span->jsonSerialize()['endTime']);
+        $this->assertRegExp(self::TIMESTAMP_FORMAT_REGEXP, $span->jsonSerialize()['startTime']);
+        $this->assertRegExp(self::TIMESTAMP_FORMAT_REGEXP, $span->jsonSerialize()['endTime']);
     }
 
     public function testSetSpanIds()
@@ -176,14 +178,14 @@ class SpanConverterTest extends TestCase
         $this->assertCount(2, $timeEvents);
         $event1 = $timeEvents[0];
         $this->assertEquals('some-description', $event1['annotation']['description']['value']);
-        $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $event1['time']);
+        $this->assertRegExp(self::TIMESTAMP_FORMAT_REGEXP, $event1['time']);
 
         $event2 = $timeEvents[1];
         $this->assertEquals('SENT', $event2['messageEvent']['type']);
         $this->assertEquals('message-id', $event2['messageEvent']['id']);
         $this->assertEquals(234, $event2['messageEvent']['uncompressedSizeBytes']);
         $this->assertEquals(123, $event2['messageEvent']['compressedSizeBytes']);
-        $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $event2['time']);
+        $this->assertRegExp(self::TIMESTAMP_FORMAT_REGEXP, $event2['time']);
     }
 
     public function testStatus()

--- a/tests/unit/Stackdriver/SpanConverterTest.php
+++ b/tests/unit/Stackdriver/SpanConverterTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright 2017 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Unit\Trace\Exporter\Stackdriver;
+
+use OpenCensus\Trace\Exporter\Stackdriver\SpanConverter;
+use OpenCensus\Trace\Span as OCSpan;
+use Prophecy\Argument;
+use Google\Cloud\Trace\Span;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group trace
+ */
+class SpanConverterTest extends TestCase
+{
+    /**
+     * @var SpanData[]
+     */
+    private $spans;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->spans = array_map(function ($span) {
+            return $span->spanData();
+        }, [
+            new OCSpan([
+                'name' => 'span',
+                'startTime' => microtime(true),
+                'endTime' => microtime(true) + 10
+            ])
+        ]);
+    }
+
+    public function testFormatsTrace()
+    {
+        $span = new OCSpan([
+            'name' => 'span',
+            'startTime' => microtime(true),
+            'endTime' => microtime(true) + 10
+        ]);
+        $span = SpanConverter::convertSpan($span->spanData());
+
+        $this->assertInstanceOf(Span::class, $span);
+        $this->assertInternalType('string', $span->name());
+        $this->assertInternalType('string', $span->spanId());
+        $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $span->jsonSerialize()['startTime']);
+        $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $span->jsonSerialize()['endTime']);
+    }
+
+    public function testFormatsStackTrace()
+    {
+        $span = new OCSpan([
+            'stackTrace' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS),
+            'startTime' => microtime(true),
+            'endTime' => microtime(true) + 10
+        ]);
+
+        $spans = SpanConverter::convertSpan($span->spanData());
+
+        $data = $spans->jsonSerialize();
+        $this->assertArrayHasKey('stackTrace', $data);
+    }
+
+    /**
+     * @dataProvider attributesToTest
+     */
+    public function testMapsAttributes($key, $value, $expectedAttributeKey, $expectedAttributeValue)
+    {
+        $span = new OCSpan([
+            'attributes' => [
+                $key => $value
+            ],
+            'startTime' => microtime(true),
+            'endTime' => microtime(true) + 10
+        ]);
+
+        $span = SpanConverter::convertSpan($span->spanData());
+
+        $attributes = $span->jsonSerialize()['attributes'];
+        $this->assertArrayHasKey($expectedAttributeKey, $attributes);
+        $this->assertEquals($expectedAttributeValue, $attributes[$expectedAttributeKey]);
+    }
+
+    public function attributesToTest()
+    {
+        return [
+            ['http.host', 'foo.example.com', '/http/host', 'foo.example.com'],
+            ['http.port', '80', '/http/port', '80'],
+            ['http.path', '/foobar', '/http/url', '/foobar'],
+            ['http.method', 'PUT', '/http/method', 'PUT'],
+            ['http.user_agent', 'user agent', '/http/user_agent', 'user agent']
+        ];
+    }
+}

--- a/tests/unit/Stackdriver/SpanConverterTest.php
+++ b/tests/unit/Stackdriver/SpanConverterTest.php
@@ -18,8 +18,13 @@
 namespace OpenCensus\Tests\Unit\Trace\Exporter\Stackdriver;
 
 use OpenCensus\Trace\Exporter\Stackdriver\SpanConverter;
+use OpenCensus\Trace\Annotation as OCAnnotation;
+use OpenCensus\Trace\Link as OCLink;
+use OpenCensus\Trace\MessageEvent as OCMessageEvent;
 use OpenCensus\Trace\Span as OCSpan;
+use OpenCensus\Trace\Status as OCStatus;
 use Prophecy\Argument;
+use Google\Cloud\Trace\Link;
 use Google\Cloud\Trace\Span;
 use PHPUnit\Framework\TestCase;
 
@@ -59,8 +64,23 @@ class SpanConverterTest extends TestCase
         $this->assertInstanceOf(Span::class, $span);
         $this->assertInternalType('string', $span->name());
         $this->assertInternalType('string', $span->spanId());
+        $this->assertNull($span->parentSpanId());
         $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $span->jsonSerialize()['startTime']);
         $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $span->jsonSerialize()['endTime']);
+    }
+
+    public function testSetSpanIds()
+    {
+        $span = new OCSpan([
+            'name' => 'span',
+            'spanId' => 'aaa',
+            'parentSpanId' => 'bbb',
+            'startTime' => microtime(true),
+            'endTime' => microtime(true) + 10
+        ]);
+        $span = SpanConverter::convertSpan($span->spanData());
+        $this->assertEquals('0000000000000aaa', $span->spanId());
+        $this->assertEquals('0000000000000bbb', $span->parentSpanId());
     }
 
     public function testFormatsStackTrace()
@@ -104,7 +124,92 @@ class SpanConverterTest extends TestCase
             ['http.port', '80', '/http/port', '80'],
             ['http.path', '/foobar', '/http/url', '/foobar'],
             ['http.method', 'PUT', '/http/method', 'PUT'],
-            ['http.user_agent', 'user agent', '/http/user_agent', 'user agent']
+            ['http.user_agent', 'user agent', '/http/user_agent', 'user agent'],
+            ['random.key', 'some value', 'random.key', 'some value']
         ];
+    }
+
+    public function testLinks()
+    {
+        $span = new OCSpan([
+            'startTime' => microtime(true),
+            'endTime' => microtime(true) + 10,
+            'links' => [
+                new OCLink('traceid', 'spanid', [
+                    'type' => OCLink::TYPE_CHILD_LINKED_SPAN,
+                    'attributes' => [
+                        'foo' => 'bar'
+                    ]
+                ])
+            ]
+        ]);
+        $span = SpanConverter::convertSpan($span->spanData());
+        $data = json_decode(json_encode($span), true)['links']['link'];
+        $this->assertCount(1, $data);
+        $link = $data[0];
+        $this->assertEquals('traceid', $link['traceId']);
+        $this->assertEquals('spanid', $link['spanId']);
+        $this->assertEquals('CHILD_LINKED_SPAN', $link['type']);
+        $this->assertEquals('bar', $link['attributes']['attributeMap']['foo']['stringValue']['value']);
+    }
+
+    public function testTimeEvents()
+    {
+        $span = new OCSpan([
+            'traceId' => 'aaa',
+            'timeEvents' => [
+                new OCAnnotation('some-description', [
+                    'attributes' => ['foo' => 'bar']
+                ]),
+                new OCMessageEvent(OCMessageEvent::TYPE_SENT, 'message-id', [
+                    'uncompressedSize' => 234,
+                    'compressedSize' => 123
+                ])
+            ],
+            'startTime' => new \DateTime(),
+            'endTime' => new \DateTime(),
+            'stackTrace' => []
+        ]);
+        $span = SpanConverter::convertSpan($span->spanData());
+
+        $timeEvents = json_decode(json_encode($span), true)['timeEvents']['timeEvent'];
+        $this->assertCount(2, $timeEvents);
+        $event1 = $timeEvents[0];
+        $this->assertEquals('some-description', $event1['annotation']['description']['value']);
+        $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $event1['time']);
+
+        $event2 = $timeEvents[1];
+        $this->assertEquals('SENT', $event2['messageEvent']['type']);
+        $this->assertEquals('message-id', $event2['messageEvent']['id']);
+        $this->assertEquals(234, $event2['messageEvent']['uncompressedSizeBytes']);
+        $this->assertEquals(123, $event2['messageEvent']['compressedSizeBytes']);
+        $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $event2['time']);
+    }
+
+    public function testStatus()
+    {
+        $span = new OCSpan([
+            'startTime' => microtime(true),
+            'endTime' => microtime(true) + 10,
+            'status' => new OCStatus(
+                200,
+                'OK'
+            )
+        ]);
+        $span = SpanConverter::convertSpan($span->spanData());
+        $data = json_decode(json_encode($span), true);
+        $this->assertEquals(200, $data['status']['code']);
+        $this->assertEquals('OK', $data['status']['message']);
+    }
+
+    public function testEmptyStatus()
+    {
+        $span = new OCSpan([
+            'startTime' => microtime(true),
+            'endTime' => microtime(true) + 10
+        ]);
+        $span = SpanConverter::convertSpan($span->spanData());
+        $data = json_decode(json_encode($span), true);
+        $this->assertTrue(!isset($data['status']));
     }
 }

--- a/tests/unit/StackdriverExporterTest.php
+++ b/tests/unit/StackdriverExporterTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017 OpenCensus Authors
+ * Copyright 2018 OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/StackdriverExporterTest.php
+++ b/tests/unit/StackdriverExporterTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2018 OpenCensus Authors
+ * Copyright 2017 OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,70 @@
 
 namespace OpenCensus\Tests\Unit\Trace\Exporter;
 
+require_once __DIR__ . '/mock_error_log.php';
+
 use OpenCensus\Trace\Exporter\StackdriverExporter;
+use OpenCensus\Trace\SpanContext;
+use OpenCensus\Trace\Tracer\TracerInterface;
+use OpenCensus\Trace\Tracer\ContextTracer;
+use OpenCensus\Trace\Span as OCSpan;
+use Prophecy\Argument;
+use Google\Cloud\Trace\Trace;
+use Google\Cloud\Trace\Span;
+use Google\Cloud\Trace\TraceClient;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group trace
+ */
 class StackdriverExporterTest extends TestCase
 {
-    public function testBasic()
+    /**
+     * @var TraceClient
+     */
+    private $client;
+
+    /**
+     * @var SpanData[]
+     */
+    private $spans;
+
+    public function setUp()
     {
-        $this->markTestSkipped();
+        parent::setUp();
+        $this->client = $this->prophesize(TraceClient::class);
+
+        $this->spans = array_map(function ($span) {
+            return $span->spanData();
+        }, [
+            new OCSpan([
+                'name' => 'span',
+                'startTime' => microtime(true),
+                'endTime' => microtime(true) + 10
+            ])
+        ]);
+    }
+
+    public function testReportWithAnExceptionErrorLog()
+    {
+        $this->client->insert(Argument::any())->willThrow(
+            new \Exception('error_log test')
+        );
+        $trace = $this->prophesize(Trace::class);
+        $trace->setSpans(Argument::any())->shouldBeCalled();
+        $this->client->trace(Argument::any())->willReturn($trace->reveal());
+        $exporter = new StackdriverExporter(
+            ['client' => $this->client->reveal()]
+        );
+        $this->expectOutputString(
+            'Reporting the Trace data failed: error_log test'
+        );
+        $this->assertFalse($exporter->export($this->spans));
+    }
+
+    public function testEmptyTrace()
+    {
+        $exporter = new StackdriverExporter(['client' => $this->client->reveal()]);
+        $this->assertFalse($exporter->export([]));
     }
 }

--- a/tests/unit/mock_error_log.php
+++ b/tests/unit/mock_error_log.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright 2017 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Exporter;
+
+/**
+ * A mock function for testing error_log function.
+ */
+
+function error_log($msg)
+{
+    echo $msg;
+}

--- a/tests/unit/mock_error_log.php
+++ b/tests/unit/mock_error_log.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017 OpenCensus Authors
+ * Copyright 2018 OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Splits span conversion into new `SpanConverter` class for easier testing.