### PR TITLE
Add exporter version to agent label and add agent label to all spans

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,8 +4,11 @@ The PHP library and extension are released independently of each other.
 
 ## Packagist Package
 
+1. Bump the `VERSION` constant in [`StackdriverExporter`][exporter]
+
 1. Create a GitHub release.
 
 1. Click `Update` from the admin view of the [opencensus/opencensus-exporter-stackdriver][packagist] package.
 
 [packagist]: https://packagist.org/packages/opencensus/opencensus-exporter-stackdriver
+[exporter]: https://github.com/census-ecosystem/opencensus-php-exporter-stackdriver/blob/master/src/StackdriverExporter.php

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "library",
     "require": {
         "php": ">=5.6",
-        "opencensus/opencensus": "~0.4",
-        "google/cloud-trace": "~0.4"
+        "opencensus/opencensus": "~0.5",
+        "google/cloud-trace": "~0.9"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/src/Stackdriver/SpanConverter.php
+++ b/src/Stackdriver/SpanConverter.php
@@ -57,7 +57,8 @@ class SpanConverter
     ];
 
     const AGENT = 'g.co/agent';
-    const AGENT_STRING = 'opencensus-php [' . Version::VERSION . '] php-stackdriver-exporter [' . StackdriverExporter::VERSION . ']';
+    const AGENT_STRING = 'opencensus-php [' . Version::VERSION . '] php-stackdriver-exporter [' .
+        StackdriverExporter::VERSION . ']';
 
     /**
      * Convert an OpenCensus SpanData to its Stackdriver Trace representation.

--- a/src/Stackdriver/SpanConverter.php
+++ b/src/Stackdriver/SpanConverter.php
@@ -28,6 +28,7 @@ use OpenCensus\Trace\MessageEvent as OCMessageEvent;
 use OpenCensus\Trace\Span as OCSpan;
 use OpenCensus\Trace\Status as OCStatus;
 use OpenCensus\Trace\SpanData;
+use OpenCensus\Trace\Exporter\StackdriverExporter;
 
 /**
  * This class handles converting from the OpenCensus data model into its
@@ -83,7 +84,9 @@ class SpanConverter
 
     private static function convertAttributes(array $attributes)
     {
-        $newAttributes = [];
+        $newAttributes = [
+            StackdriverExporter::AGENT => StackdriverExporter::AGENT_STRING
+        ];
         foreach ($attributes as $key => $value) {
             if (array_key_exists($key, self::ATTRIBUTE_MAP)) {
                 $newAttributes[self::ATTRIBUTE_MAP[$key]] = $value;

--- a/src/Stackdriver/SpanConverter.php
+++ b/src/Stackdriver/SpanConverter.php
@@ -56,7 +56,7 @@ class SpanConverter
         OCMessageEvent::TYPE_RECEIVED => MessageEvent::TYPE_RECEIVED
     ];
 
-    const AGENT = 'g.co/agent';
+    const AGENT_KEY = 'g.co/agent';
     const AGENT_STRING = 'opencensus-php [' . Version::VERSION . '] php-stackdriver-exporter [' .
         StackdriverExporter::VERSION . ']';
 
@@ -90,7 +90,7 @@ class SpanConverter
     private static function convertAttributes(array $attributes)
     {
         $newAttributes = [
-            self::AGENT => self::AGENT_STRING
+            self::AGENT_KEY => self::AGENT_STRING
         ];
         foreach ($attributes as $key => $value) {
             if (array_key_exists($key, self::ATTRIBUTE_MAP)) {

--- a/src/Stackdriver/SpanConverter.php
+++ b/src/Stackdriver/SpanConverter.php
@@ -29,6 +29,7 @@ use OpenCensus\Trace\Span as OCSpan;
 use OpenCensus\Trace\Status as OCStatus;
 use OpenCensus\Trace\SpanData;
 use OpenCensus\Trace\Exporter\StackdriverExporter;
+use OpenCensus\Version;
 
 /**
  * This class handles converting from the OpenCensus data model into its
@@ -54,6 +55,9 @@ class SpanConverter
         OCMessageEvent::TYPE_SENT => MessageEvent::TYPE_SENT,
         OCMessageEvent::TYPE_RECEIVED => MessageEvent::TYPE_RECEIVED
     ];
+
+    const AGENT = 'g.co/agent';
+    const AGENT_STRING = 'opencensus-php [' . Version::VERSION . '] php-stackdriver-exporter [' . StackdriverExporter::VERSION . ']';
 
     /**
      * Convert an OpenCensus SpanData to its Stackdriver Trace representation.
@@ -85,7 +89,7 @@ class SpanConverter
     private static function convertAttributes(array $attributes)
     {
         $newAttributes = [
-            StackdriverExporter::AGENT => StackdriverExporter::AGENT_STRING
+            self::AGENT => self::AGENT_STRING
         ];
         foreach ($attributes as $key => $value) {
             if (array_key_exists($key, self::ATTRIBUTE_MAP)) {

--- a/src/StackdriverExporter.php
+++ b/src/StackdriverExporter.php
@@ -52,7 +52,9 @@ use OpenCensus\Version;
  */
 class StackdriverExporter implements ExporterInterface
 {
+    const VERSION = '0.1.0';
     const AGENT = 'g.co/agent';
+    const AGENT_STRING = 'opencensus-php [' . Version::VERSION . '] php-stackdriver-exporter [' . self::VERSION . ']';
 
     use BatchTrait;
 
@@ -122,10 +124,6 @@ class StackdriverExporter implements ExporterInterface
         $rootSpan = $spans[0];
         $trace = self::$client->trace(
             $rootSpan->traceId()
-        );
-        $rootSpan->addAttribute(
-            self::AGENT,
-            sprintf('opencensus-php [%s]', Version::VERSION)
         );
 
         // build a Trace object and assign Spans

--- a/src/StackdriverExporter.php
+++ b/src/StackdriverExporter.php
@@ -24,7 +24,6 @@ use Google\Cloud\Trace\Span;
 use Google\Cloud\Trace\Trace;
 use OpenCensus\Trace\SpanData;
 use OpenCensus\Trace\Exporter\Stackdriver\SpanConverter;
-use OpenCensus\Version;
 
 /**
  * This implementation of the ExporterInterface use the BatchRunner to provide
@@ -53,8 +52,6 @@ use OpenCensus\Version;
 class StackdriverExporter implements ExporterInterface
 {
     const VERSION = '0.1.0';
-    const AGENT = 'g.co/agent';
-    const AGENT_STRING = 'opencensus-php [' . Version::VERSION . '] php-stackdriver-exporter [' . self::VERSION . ']';
 
     use BatchTrait;
 

--- a/tests/unit/StackdriverExporterTest.php
+++ b/tests/unit/StackdriverExporterTest.php
@@ -95,9 +95,9 @@ class StackdriverExporterTest extends TestCase
         $trace = $this->prophesize(Trace::class);
         $trace->setSpans(Argument::that(function ($spans) {
             $this->assertCount(1, $spans);
-            $attributes = $spans[0]->jsonSerialize()['attributes'];
+            $attributes = $spans[0]->info()['attributes']['attributeMap'];
             $this->assertArrayHasKey('g.co/agent', $attributes);
-            $this->assertRegexp('/\d+\.\d+\.\d+/', $attributes['g.co/agent']);
+            $this->assertRegexp('/\d+\.\d+\.\d+/', $attributes['g.co/agent']['stringValue']['value']);
             return true;
         }))->shouldBeCalled();
         $this->client->trace('aaa')->willReturn($trace->reveal());


### PR DESCRIPTION
* Add the agent label to all spans.
* Adds `VERSION` constant to `StackdriverExporter` which much be bumped for each exporter release. Updated `RELEASING.md` to reflect this change.
* Fixed tests that relied on internal `jsonSerialize()` functionality and hard-coded string constants in `google/cloud-trace` library.

Fixes #9 